### PR TITLE
Improves clarity of BUILD file by removing unnecessary code and commenting

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,7 +14,7 @@ git_repository(
 git_repository(
     name="graknlabs_bazel_distribution",
     remote="https://github.com/graknlabs/bazel-distribution",
-    commit="ebc9ae9e6d4ef0086d1c6731bf6f5f8a8f40b509"
+    commit="27c8bf9e5d9f9b11b2a70dc2697da196d69f799c"
 )
 
 ## Only needed for PIP support:

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -15,27 +15,11 @@ py_test(
     ]
 )
 
-py_test(
-     name = "local_end_to_end_test",
-     main = "end_to_end_test.py",
-     srcs = [
-         "kgcn/animal_trade/test/end_to_end_test.py"
-     ],
-     deps = [
-         "//kglib:kglib",
-     ],
-     data = [
-         "@animaltrade_dist//file",
-     ]
-)
-
 
 py_library(
     name = "test-pypi-kglib",
-    srcs = [
-        "kgcn/animal_trade/test/end_to_end_test.py"
-    ],
     deps = [
+        # Import kglib from PyPi, not from local source
         requirement('grakn-kglib'),
 
         # Grakn deps

--- a/examples/kgcn/animal_trade/README.md
+++ b/examples/kgcn/animal_trade/README.md
@@ -5,7 +5,7 @@
 **Requirements:**
 
 - Python 3.6.3 < version < 3.7 ([tensorflow doesn't yet support Python 3.7](https://github.com/tensorflow/tensorflow/issues/17022))
-- kglib installed from pip: `pip install --extra-index-url https://test.pypi.org/simple/ grakn-kglib`
+- kglib installed from pip: `pip install grakn-kglib`
 - The source code in order to access the example `git clone https://github.com/graknlabs/kglib.git`
 - The `grakn-animaltrade.zip` dataset from the [latest release](https://github.com/graknlabs/kglib/releases/latest). This is a dataset that has been pre-loaded into Grakn v1.5 (so you don't have to run the data import yourself), with two keyspaces: `animaltrade_train` and `animaltrade_test`
 

--- a/examples/kgcn/animal_trade/test/end_to_end_test.py
+++ b/examples/kgcn/animal_trade/test/end_to_end_test.py
@@ -58,10 +58,6 @@ POPULATION_SIZE_PER_CLASS = 100
 # Params for persisting to files
 DIR = os.path.dirname(os.path.realpath(__file__))
 TIMESTAMP = time.strftime("%Y-%m-%d_%H-%M-%S")
-# BASE_PATH = f'{DIR}/dataset/{NUM_PER_CLASS}_concepts/'
-# flags.DEFINE_string('log_dir', BASE_PATH + 'out/out_' + TIMESTAMP, 'directory to use to store data from training')
-
-# SAVED_LABELS_PATH = BASE_PATH + 'labels/labels_{}.p'
 
 TRAIN = 'train'
 EVAL = 'eval'


### PR DESCRIPTION
- A local end-to-end test was helpful for debugging CI, but shouldn't be needed further.
- The end-to-end test source was being included twice, it should only be included in the test.
- Make clear that this requires `grakn-kglib` installed from PyPi