### PR TITLE
Build corrections

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
       - run: sudo apt-get update
       - run: pyenv install 3.6.3
       - run: pyenv global 3.6.3
-      - run: bazel run //:deploy-pip -- test $PYPI_TEST_SERVER_USERNAME $PYPI_TEST_SERVER_PASSWORD
+      - run: bazel run //:deploy-pip -- pypi $PYPI_USERNAME $PYPI_PASSWORD
 
 workflows:
   version: 2

--- a/BUILD
+++ b/BUILD
@@ -11,10 +11,8 @@ deploy_pip(
     package_name = "grakn-kglib",
     version_file = "//:VERSION",
     classifiers = [
-        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Intended Audience :: Developers",

--- a/examples/kgcn/animal_trade/README.md
+++ b/examples/kgcn/animal_trade/README.md
@@ -4,8 +4,7 @@
 
 **Requirements:**
 
-- Python 3.6.3 < version < 3.7 ([tensorflow doesn't yet support Python 3.7](https://github.com/tensorflow/tensorflow/issues/17022))
-- kglib installed from pip: `pip install grakn-kglib`
+- The requirements listed in the [KGCN quickstart](https://github.com/graknlabs/kglib/tree/master/kglib/kgcn#quickstart)
 - The source code in order to access the example `git clone https://github.com/graknlabs/kglib.git`
 - The `grakn-animaltrade.zip` dataset from the [latest release](https://github.com/graknlabs/kglib/releases/latest). This is a dataset that has been pre-loaded into Grakn v1.5 (so you don't have to run the data import yourself), with two keyspaces: `animaltrade_train` and `animaltrade_test`
 

--- a/kglib/kgcn/README.md
+++ b/kglib/kgcn/README.md
@@ -6,9 +6,9 @@ This project introduces a novel model: the *Knowledge Graph Convolutional Networ
 
 **Requirements:**
 
-- Python 3.6.3 < version < 3.7 ([tensorflow doesn't yet support Python 3.7](https://github.com/tensorflow/tensorflow/issues/17022))
+- Python 3.6.3 <= version < 3.7 ([tensorflow doesn't yet support Python 3.7](https://github.com/tensorflow/tensorflow/issues/17022))
 
-- kglib installed from pip: `pip install --extra-index-url https://test.pypi.org/simple/ grakn-kglib`
+- kglib installed from pip: `pip install grakn-kglib`
 
 ### Usage
 
@@ -47,7 +47,7 @@ transaction.close()
 session.close()
 ```
 
-There is also a [full example](https://github.com/graknlabs/kglib/examples/kgcn/animal_trade) which outlines retrieving sample concepts with labels and working with separate keyspaces for training and testing.  
+There is also a [full example](https://github.com/graknlabs/kglib/tree/master/examples/kgcn/animal_trade) which outlines retrieving sample concepts with labels and working with separate keyspaces for training and testing.
 
 ## Methodology
 

--- a/kglib/kgcn/encoder/tf_hub.py
+++ b/kglib/kgcn/encoder/tf_hub.py
@@ -24,7 +24,11 @@ import tensorflow as tf
 class TensorFlowHubEncoder:
 
     def __init__(self, module_url, output_feature_length, name='tf_hub_encoder'):
+        print(f'Initialising TensorFlow Hub Encoder op\n'
+              f'This may take a long time on its first run, as a pre-trained network module ({module_url}) needs to be '
+              f'downloaded...')
         self._embed = hub.Module(module_url)
+        print('...Encoder op initialised')
         self._name = name
         self._output_feature_length = output_feature_length
 


### PR DESCRIPTION
- Corrects applicable Python versions for PyPi deployment
- Corrects installation instructions, and makes the `animaltrade` example requirements reference the general KGCN requirements
- Fixes the broken link to the `animaltrade` example in the KGCN README
- Prints warnings at runtime to warn the user that the TensorFlow Hub module used may take some time to download, so that they know the process hasn't hung

Addresses #37 #38 