### PR TITLE
Depend upon build-tools rather than bazel-distribution

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,47 +21,20 @@ pip_repositories()
 
 
 ########################################################################################################################
-# Load Bazel Distribution
+# Load Build Tools
 ########################################################################################################################
 
-# Load Bazel Distribution here, since it is required for kglib and for grakn
-load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_bazel_distribution")
+load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_build_tools")
+graknlabs_build_tools()
+
+
+########################################################################################################################
+# Load Pip Distribution Requirements
+########################################################################################################################
+
+load("@graknlabs_build_tools//distribution:dependencies.bzl", "graknlabs_bazel_distribution")
 graknlabs_bazel_distribution()
 
-# --- Load the dependencies of graknlabs_bazel_distribution ---
-
-load("@graknlabs_bazel_distribution//github:dependencies.bzl", "github_dependencies_for_deployment")
-github_dependencies_for_deployment()
-
-#load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-
-git_repository(
-    name = "io_bazel_skydoc",
-    remote = "https://github.com/graknlabs/skydoc.git",
-    branch = "experimental-skydoc-allow-dep-on-bazel-tools",
-)
-
-load("@io_bazel_skydoc//:setup.bzl", "skydoc_repositories")
-skydoc_repositories()
-
-load("@io_bazel_rules_sass//:package.bzl", "rules_sass_dependencies")
-rules_sass_dependencies()
-
-load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
-node_repositories()
-
-load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
-sass_repositories()
-
-# Skip these graknlabs_bazel_distribution dependencies since they are already present
-#git_repository(
-#    name = "io_bazel_rules_python",
-#    remote = "https://github.com/bazelbuild/rules_python.git",
-#    commit = "fdbb17a4118a1728d19e638a5291b4c4266ea5b8",
-#)
-
-#load("@io_bazel_rules_python//python:pip.bzl", "pip_repositories", "pip3_import")
-#pip_repositories()
 
 pip3_import(
     name = "graknlabs_bazel_distribution_pip",
@@ -69,7 +42,6 @@ pip3_import(
 )
 load("@graknlabs_bazel_distribution_pip//:requirements.bzl", graknlabs_bazel_distribution_pip_install = "pip_install")
 graknlabs_bazel_distribution_pip_install()
-
 
 
 ###################################
@@ -116,13 +88,11 @@ graknlabs_grakn_core()
 
 load(
     "@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl",
-    "graknlabs_build_tools",
     "graknlabs_graql",
     "graknlabs_protocol",
     "graknlabs_client_java",
     "graknlabs_benchmark"
 )
-graknlabs_build_tools()
 graknlabs_graql()
 graknlabs_protocol()
 graknlabs_client_java()

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -9,11 +9,11 @@ def io_bazel_rules_python():
         commit = "4443fa25feac79b0e4c7c63ca84f87a1d6032f49"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @io_bazel_rules_python
     )
 
-def graknlabs_bazel_distribution():
+def graknlabs_build_tools():
     git_repository(
-        name="graknlabs_bazel_distribution",
-        remote="https://github.com/graknlabs/bazel-distribution",
-        commit="8dc6490f819d330361f46201e3390ce5457564a2"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_bazel_distribution
+        name = "graknlabs_build_tools",
+        remote = "https://github.com/graknlabs/build-tools",
+        commit = "02a6698a61aa4e63304deb2c1b364a46c305162f", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -13,14 +13,15 @@ def graknlabs_bazel_distribution():
     git_repository(
         name="graknlabs_bazel_distribution",
         remote="https://github.com/graknlabs/bazel-distribution",
-        commit="62a9a6343e9f2a1aeed7c935e9092c0fd1e8e8ac"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_bazel_distribution
+        commit="8dc6490f819d330361f46201e3390ce5457564a2"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_bazel_distribution
     )
+
 
 def graknlabs_grakn_core():
     git_repository(
         name="graknlabs_grakn_core",
         remote="https://github.com/graknlabs/grakn",
-        commit="2845bb009876a74896bd479a7e49955c7fa1c7ca"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit="9dede119f3495c3611ccc7e3d65c076bcb71ea71"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_client_python():


### PR DESCRIPTION
## What is the goal of this PR?

KGLIB should not directly sync from `graknlabs/bazel-distribution`, instead KGLIB should sync from `graknlabs/build-tools`. Required for #76.

## What are the changes implemented in this PR?
- Brings the graknlabs dependencies up to their latest commits
- Updates dependency upon `bazel-distribution` to be found in the dependencies of `build-tools`