### PR TITLE
Move non-Grakn Dependency

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,7 +12,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 # We require loading bazel_rules from the graknlabs fork, not from bazel, since we've patched the python rules to work with TensorFlow
-load("//dependencies/graknlabs:dependencies.bzl", "io_bazel_rules_python")
+load("//dependencies/python:dependencies.bzl", "io_bazel_rules_python")
 io_bazel_rules_python()
 
 ## Only needed for PIP support:

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -1,14 +1,5 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
-
-def io_bazel_rules_python():
-    git_repository(
-        name = "io_bazel_rules_python",
-        # Grakn python rules
-        remote = "https://github.com/graknlabs/rules_python.git",
-        commit = "4443fa25feac79b0e4c7c63ca84f87a1d6032f49"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @io_bazel_rules_python
-    )
-
 def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",

--- a/dependencies/python/dependencies.bzl
+++ b/dependencies/python/dependencies.bzl
@@ -6,5 +6,5 @@ def io_bazel_rules_python():
         name = "io_bazel_rules_python",
         # Grakn python rules
         remote = "https://github.com/graknlabs/rules_python.git",
-        commit = "4443fa25feac79b0e4c7c63ca84f87a1d6032f49"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @io_bazel_rules_python
+        commit = "4443fa25feac79b0e4c7c63ca84f87a1d6032f49"  
     )

--- a/dependencies/python/dependencies.bzl
+++ b/dependencies/python/dependencies.bzl
@@ -1,0 +1,10 @@
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+
+def io_bazel_rules_python():
+    git_repository(
+        name = "io_bazel_rules_python",
+        # Grakn python rules
+        remote = "https://github.com/graknlabs/rules_python.git",
+        commit = "4443fa25feac79b0e4c7c63ca84f87a1d6032f49"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @io_bazel_rules_python
+    )


### PR DESCRIPTION
## What is the goal of this PR?
The current structure of `dependencies/graknlabs/dependencies.bzl` was breaking graql and `sync-dependencies` because it contained a non-graknlabs dependency.

## What are the changes implemented in this PR?
* Create a new package `dependencies/python`
* move relevant rule from `graknlabs/dependencies.bzl` to `python/dependencies.bzl`
* Update WORKSPACE correspondingly