### PR TITLE
Fix dependencies graknlabs_common and graknlabs_console

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -89,13 +89,17 @@ graknlabs_grakn_core()
 load(
     "@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl",
     "graknlabs_graql",
+    "graknlabs_common",
     "graknlabs_protocol",
     "graknlabs_client_java",
+    "graknlabs_console",
     "graknlabs_benchmark"
 )
 graknlabs_graql()
+graknlabs_common()
 graknlabs_protocol()
 graknlabs_client_java()
+graknlabs_console()
 graknlabs_benchmark()
 
 # Skip since these are already present above


### PR DESCRIPTION
## What is the goal of this PR?

To fix dependencies now that Grakn Console is separated from Grakn

## What are the changes implemented in this PR?

A simple fix for the WORKSPACE