### PR TITLE
Fix permissions error when deleting the kglib release branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: git push --delete origin kglib-release-branch
+      - run: git push --delete https://$REPO_GITHUB_TOKEN@github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME $CIRCLE_BRANCH
 
 workflows:
   version: 2


### PR DESCRIPTION
## What is the goal of this PR?

Fix the last step of the release process - deleting the temporary kglib release branch

## What are the changes implemented in this PR?

A change to the git command to include the necessary credentials
