### PR TITLE
Change around end-to-end and deployment tests, add accuracy assertion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
               cat tests/deployment/requirements.txt
               pip install -r tests/deployment/requirements.txt
               ./dist/grakn-core-all-linux/grakn console -k diagnosis -f kglib/utils/grakn/synthetic/examples/diagnosis/schema.gql
-              python -m unittest kglib.kgcn.examples.diagnosis.diagnosis_end_to_end_test
+              python -m unittest kglib.kgcn.examples.diagnosis.diagnosis_deployment_test
 
   release-approval:
     machine: true

--- a/kglib/kgcn/examples/diagnosis/BUILD
+++ b/kglib/kgcn/examples/diagnosis/BUILD
@@ -16,6 +16,7 @@ py_test(
 
 py_test(
     name = "diagnosis_end_to_end_test",
+    size = "large",
     srcs = [
         "diagnosis_end_to_end_test.py"
     ],

--- a/kglib/kgcn/examples/diagnosis/BUILD
+++ b/kglib/kgcn/examples/diagnosis/BUILD
@@ -15,9 +15,9 @@ py_test(
 )
 
 py_test(
-    name = "diagnosis_IT",
+    name = "diagnosis_end_to_end_test",
     srcs = [
-        "diagnosis_IT.py"
+        "diagnosis_end_to_end_test.py"
     ],
     deps = [
         "diagnosis",

--- a/kglib/kgcn/examples/diagnosis/diagnosis.py
+++ b/kglib/kgcn/examples/diagnosis/diagnosis.py
@@ -51,21 +51,23 @@ def diagnosis_example(num_graphs=60,
         print(f'Found node types: {node_types}')
         print(f'Found edge types: {edge_types}')
 
-    ge_graphs = pipeline(graphs,
-                         tr_ge_split,
-                         node_types,
-                         edge_types,
-                         num_processing_steps_tr=num_processing_steps_tr,
-                         num_processing_steps_ge=num_processing_steps_ge,
-                         num_training_iterations=num_training_iterations,
-                         categorical_attributes=CATEGORICAL_ATTRIBUTES,
-                         )
+    ge_graphs, solveds_tr, solveds_ge = pipeline(graphs,
+                                                 tr_ge_split,
+                                                 node_types,
+                                                 edge_types,
+                                                 num_processing_steps_tr=num_processing_steps_tr,
+                                                 num_processing_steps_ge=num_processing_steps_ge,
+                                                 num_training_iterations=num_training_iterations,
+                                                 categorical_attributes=CATEGORICAL_ATTRIBUTES,
+                                                 )
 
     with session.transaction().write() as tx:
         write_predictions_to_grakn(ge_graphs, tx)
 
     session.close()
     client.close()
+
+    return solveds_tr, solveds_ge
 
 
 CATEGORICAL_ATTRIBUTES = {'name': ['meningitis', 'flu', 'fever', 'light-sensitivity']}

--- a/kglib/kgcn/examples/diagnosis/diagnosis_deployment_test.py
+++ b/kglib/kgcn/examples/diagnosis/diagnosis_deployment_test.py
@@ -20,20 +20,9 @@
 import unittest
 
 from kglib.kgcn.examples.diagnosis.diagnosis import diagnosis_example
-from kglib.utils.grakn.test.base import GraknServer
-
-TEST_KEYSPACE = "diagnosis"
-TEST_URI = "localhost:48555"
 
 
 class TestDiagnosisExample(unittest.TestCase):
-    def setUp(self):
-        self._gs = GraknServer()
-        self._gs.start()
-        self._gs.load_graql_file(TEST_KEYSPACE, '/kglib/kglib/utils/grakn/synthetic/examples/diagnosis/schema.gql')
-
-    def tearDown(self):
-        self._gs.stop()
 
     def test_example_runs_without_exception(self):
         diagnosis_example(num_graphs=6,

--- a/kglib/kgcn/examples/diagnosis/diagnosis_end_to_end_test.py
+++ b/kglib/kgcn/examples/diagnosis/diagnosis_end_to_end_test.py
@@ -20,12 +20,25 @@
 import unittest
 
 from kglib.kgcn.examples.diagnosis.diagnosis import diagnosis_example
+from kglib.utils.grakn.test.base import GraknServer
+
+TEST_KEYSPACE = "diagnosis"
+TEST_URI = "localhost:48555"
 
 
 class TestDiagnosisExample(unittest.TestCase):
+    def setUp(self):
+        self._gs = GraknServer()
+        self._gs.start()
+        self._gs.load_graql_file(TEST_KEYSPACE, '/kglib/kglib/utils/grakn/synthetic/examples/diagnosis/schema.gql')
 
-    def test_example_runs_without_exception(self):
-        diagnosis_example()
+    def tearDown(self):
+        self._gs.stop()
+
+    def test_learning_is_done(self):
+        solveds_tr, solveds_ge = diagnosis_example()
+        self.assertGreaterEqual(solveds_tr[-1], 0.1)
+        self.assertGreaterEqual(solveds_tr[-1], 0.1)
 
 
 if __name__ == "__main__":

--- a/kglib/kgcn/pipeline/pipeline.py
+++ b/kglib/kgcn/pipeline/pipeline.py
@@ -134,4 +134,5 @@ def pipeline(graphs,
             data['probabilities'] = softmax(data['logits'])
             data['prediction'] = int(np.argmax(data['probabilities']))
 
-    return ge_graphs
+    _, _, _, _, _, solveds_tr, solveds_ge = tr_info
+    return ge_graphs, solveds_tr, solveds_ge


### PR DESCRIPTION
## What is the goal of this PR?

Ensure that the scope and intention of the CI jobs done on PRs vs the CI jobs done after merge make sense. All tests, including end-to-end, are needed before PRs are merged, which presently means in the `test` job. Jobs to ensure the deployment via pip works correctly are only executed on `master` after PRs are merged, and should be less extensive than the end-to-end test, but still check everything should run for a user.

## What are the changes implemented in this PR?

- Use an end-to-end test during the test job, and a much shorter end-to-end (to check all components work together) for the deployment test
- Test the accuracy of the learner, with a very low threshold
