### PR TITLE
Use release-validate-deps to ensure that kglib depends on a released version of client-python and grakn

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,15 @@ jobs:
           export RELEASE_APPROVAL_TOKEN=$REPO_GITHUB_TOKEN
           bazel run @graknlabs_build_tools//ci:release-approval
 
+  release-validate:
+    machine: true
+    steps:
+      - install-bazel-linux-rbe
+      - checkout
+      - run: |
+          bazel run @graknlabs_build_tools//ci:release-validate-deps -- \
+            graknlabs_grakn_core graknlabs_client_python
+
   deploy-github:
     machine: true
     working_directory: ~/kglib
@@ -147,10 +156,16 @@ workflows:
 
   kglib-release:
     jobs:
+      - release-validate:
+          filters:
+            branches:
+              only: kglib-release-branch
       - deploy-github:
           filters:
             branches:
               only: kglib-release-branch
+          requires:
+            - deploy-github
       - deploy-approval:
           type: approval
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,7 @@ workflows:
             branches:
               only: kglib-release-branch
           requires:
-            - deploy-github
+            - release-validate
       - deploy-approval:
           type: approval
           filters:


### PR DESCRIPTION
## What is the goal of this PR?

We have added a validation step using `//ci:release-validate-deps` in order to ensure that client-python is releasable only if it depends on a released version of protocol