### PR TITLE
Install python3 for release-validate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,7 @@ jobs:
     steps:
       - install-bazel-linux-rbe
       - checkout
+      - install-python
       - run: |
           bazel run @graknlabs_build_tools//ci:release-validate-deps -- \
             graknlabs_grakn_core graknlabs_client_python


### PR DESCRIPTION
## What is the goal of this PR?

Release validate cannot complete without a command set as `python3`.

## What are the changes implemented in this PR?

Add the `install-python` command to `release-validate`