### PR TITLE
Test the health of links in markdown files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - checkout
       - run: npm install -g markdown-link-check
-      - run: find . -name \*.md | xargs -L1 markdown-link-check -v
+      - run: find . -name \*.md | xargs -L1 npx markdown-link-check -v
 
   deploy-pip-snapshot:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
     machine: true
     working_directory: ~/kglib
     steps:
+      - checkout
       - run: gem install awesome_bot
       - run: find . -name \*.md | tr '\n' ',' | xargs awesome_bot --allow 403,301,302 --allow-dupe --base-url https:// --files
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,6 @@ jobs:
     working_directory: ~/kglib
     steps:
       - checkout
-      - run: npm install -g markdown-link-check
       - run: find . -name \*.md | xargs -L1 npx markdown-link-check -v
 
   deploy-pip-snapshot:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,13 @@ jobs:
       - install-python
       - run: bazel test //tests/end_to_end/... --test_output=streamed --spawn_strategy=standalone --python_version PY3 --python_path $(which python)
 
+  test-markdown-link-health:
+    machine: true
+    working_directory: ~/kglib
+    steps:
+      - run: gem install awesome_bot
+      - run: find . -name \*.md | tr '\n' ',' | xargs awesome_bot --allow 403,301,302 --allow-dupe --base-url https:// --files
+
   deploy-pip-snapshot:
     machine: true
     working_directory: ~/kglib
@@ -147,6 +154,10 @@ workflows:
           filters:
             branches:
               ignore: kglib-release-branch
+      - test-markdown-link-health:
+          filters:
+            branches:
+              ignore: kglib-release-branch
       - deploy-pip-snapshot:
           filters:
             branches:
@@ -155,6 +166,7 @@ workflows:
             - test
             - test-end-to-end
             - build
+            - test-markdown-link-health
       - test-deployment-pip:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,8 +53,8 @@ jobs:
     working_directory: ~/kglib
     steps:
       - checkout
-      - run: gem install awesome_bot
-      - run: find . -name \*.md | tr '\n' ',' | xargs awesome_bot --allow 403,301,302 --allow-dupe --files
+      - run: npm install -g markdown-link-check
+      - run: find . -name \*.md | xargs -L1 markdown-link-check -v
 
   deploy-pip-snapshot:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - checkout
       - run: gem install awesome_bot
-      - run: find . -name \*.md | tr '\n' ',' | xargs awesome_bot --allow 403,301,302 --allow-dupe --base-url https:// --files
+      - run: find . -name \*.md | tr '\n' ',' | xargs awesome_bot --allow 403,301,302 --allow-dupe --files
 
   deploy-pip-snapshot:
     machine: true

--- a/kglib/kgcn/README.md
+++ b/kglib/kgcn/README.md
@@ -8,7 +8,7 @@ This project introduces a novel model: the *Knowledge Graph Convolutional Networ
 
 This KGCN framework is designed to provide a versatile means of performing learning tasks over a Grakn knowledge graph, including:
 
-- Predicting the existence of new [Relations](https://dev.grakn.ai/docs/schema/concepts#relation) that between existing [Concepts](https://dev.grakn.ai/docs/concept-api/overview). These relations can be binary, **ternary** (3-way) or [**N-ary**](), since Relations in Grakn are graph [Hyperedges](https://en.wikipedia.org/wiki/Glossary_of_graph_theory_terms#hyperedge). This functionality is included in the [latest release](https://github.com/graknlabs/kglib/releases/latest).
+- Predicting the existence of new [Relations](https://dev.grakn.ai/docs/schema/concepts#relation) between existing [Concepts](https://dev.grakn.ai/docs/concept-api/overview). These relations can be binary, **ternary** (3-way) or [**N-ary**](), since Relations in Grakn are graph [Hyperedges](https://en.wikipedia.org/wiki/Glossary_of_graph_theory_terms#hyperedge). This functionality is included in the [latest release](https://github.com/graknlabs/kglib/releases/latest).
 - Predicting the values of [Attributes](https://dev.grakn.ai/docs/schema/concepts#attribute) attached to other Concepts
 - Predicting a subgraph of Entities, Relations and Attributes to complete a known graph
 - Predicting erroneous data in a graph
@@ -34,7 +34,7 @@ Once you have installed kglib via pip (as above) you can run the example as foll
 
 1. Start a Grakn server
 
-2. Load [the schema](kglib/utils/grakn/synthetic/examples/diagnosis/schema.gql) for the example into Grakn. The template for the command is `./grakn console -k diagnosis -f path/to/schema.gql`
+2. Load [the schema](../utils/grakn/synthetic/examples/diagnosis/schema.gql) for the example into Grakn. The template for the command is `./grakn console -k diagnosis -f path/to/schema.gql`
 
 3. Run the example: `python -m kglib.kgcn.examples.diagnosis.diagnosis`
 


### PR DESCRIPTION
## What is the goal of this PR?

Avoid having to click through all of the links in Markdown files to manually test if they are broken. Instead, test the health of links in markdown files automatically.

## What are the changes implemented in this PR?

Adds a CI job using `awesome_bot` to report on the link health of all repo markdown files. This should fail if any links do not validate properly.