### PR TITLE
Refactor how version is provided for artifact deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,10 +63,9 @@ jobs:
       - checkout
       - install-python
       - run: |
-          echo -n "$(cat VERSION)-$CIRCLE_SHA1" > VERSION
           export DEPLOY_PIP_USERNAME=$REPO_GRAKN_USERNAME
           export DEPLOY_PIP_PASSWORD=$REPO_GRAKN_PASSWORD
-          bazel run //:deploy-pip -- snapshot
+          bazel run --define version=$(git rev-parse HEAD) //:deploy-pip -- snapshot
 
   test-deployment-pip:
       machine: true
@@ -78,7 +77,7 @@ jobs:
         - run:
             name: Run test-deployment-pip for kglib
             command: |
-              echo -n "$(cat VERSION)-$CIRCLE_SHA1" > VERSION
+              echo -n "0.0.0-$CIRCLE_SHA1" > VERSION
               sed -i -e "s/KGLIB_VERSION_MARKER/$(cat VERSION)/g" tests/deployment/requirements.txt
               cat tests/deployment/requirements.txt
               pip install -r tests/deployment/requirements.txt
@@ -131,7 +130,7 @@ jobs:
       - run: |
           export DEPLOY_PIP_USERNAME=$REPO_PYPI_USERNAME
           export DEPLOY_PIP_PASSWORD=$REPO_PYPI_PASSWORD
-          bazel run //:deploy-pip -- release
+          bazel run --define version=$(cat VERSION) //:deploy-pip -- release
 
   release-cleanup:
     machine: true

--- a/BUILD
+++ b/BUILD
@@ -9,7 +9,6 @@ load("@graknlabs_bazel_distribution//pip:rules.bzl", "assemble_pip", "deploy_pip
 assemble_pip(
     name = "assemble-pip",
     target = "//kglib:kglib",
-    version_file = "//:VERSION",
     package_name = "grakn-kglib",
     classifiers = [
         "Programming Language :: Python :: 3",

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -4,7 +4,7 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "54109ff7428d0b7c04bd30ecff6f7e77f32c1bfd", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "499a203981325e3ee50e3fc2f5298bad8a6bf683", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 


### PR DESCRIPTION
## What is the goal of this PR?

Adapt `@graknlabs_kglib` to latest changes in bazel-distribution (in particular, graknlabs/bazel-distribution#150)

## What are the changes implemented in this PR?

Instead of supplying `version_file` everywhere, use `--define version=<>` as a Bazel argument to supply version.

