### PR TITLE
Fix test-deployment-pip CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ commands:
   run-grakn-server:
     steps:
       - install-bazel-linux-rbe
+      - install-python
       - run: bazel build @graknlabs_grakn_core//:assemble-linux-targz
       - run: mkdir dist && tar -xvzf bazel-genfiles/external/graknlabs_grakn_core/grakn-core-all-linux.tar.gz -C ./dist/
       - run: nohup ./dist/grakn-core-all-linux/grakn server start
@@ -72,7 +73,6 @@ jobs:
       working_directory: ~/kglib
       steps:
         - checkout
-        - install-python
         - run-grakn-server
         - run:
             name: Run test-deployment-pip for kglib


### PR DESCRIPTION
## What is the goal of this PR?

Previously, `test-deployment-pip` would fail because we tried to fetch Python dependencies with Python 2 whereas `kglib` is a Py3-only project. This PR configures CircleCI machine such that `pip` points to Python 3's `pip`

## What are the changes implemented in this PR?

Move `install-python` (which sets `pip` -> `pip3`) step to be after `install-bazel-linux-rbe` (which sets `pip` -> `pip2`)