### PR TITLE
Remove Global Block and Input Field of Graphs

### DIFF
--- a/kglib/kgcn/examples/diagnosis/diagnosis.py
+++ b/kglib/kgcn/examples/diagnosis/diagnosis.py
@@ -106,13 +106,13 @@ def create_concept_graphs(example_indices, grakn_session):
 
 
 # Existing elements in the graph are those that pre-exist in the graph, and should be predicted to continue to exist
-PREEXISTS = dict(input=1, solution=0)
+PREEXISTS = dict(solution=0)
 
-# Candidates are neither present in the input nor in the solution, they are negative examples
-CANDIDATE = dict(input=0, solution=1)
+# Candidates are neither present in the input nor in the solution, they are negative samples
+CANDIDATE = dict(solution=1)
 
-# Elements to infer are the graph elements whose existence we want to predict to be true, they are positive examples
-TO_INFER = dict(input=0, solution=2)
+# Elements to infer are the graph elements whose existence we want to predict to be true, they are positive samples
+TO_INFER = dict(solution=2)
 
 
 class QueryHandler:

--- a/kglib/kgcn/learn/learn_IT.py
+++ b/kglib/kgcn/learn/learn_IT.py
@@ -31,24 +31,22 @@ from kglib.kgcn.models.embedding import ThingEmbedder, RoleEmbedder
 class ITKGCNLearner(unittest.TestCase):
     def test_learner_runs(self):
         input_graph = nx.MultiDiGraph()
-        # TODO Remove 'input' and 'solution' fields, only needed for plotting which should be separated
-        input_graph.add_node(0, type='person', features=np.array([0, 1, 2], dtype=np.float32))
-        input_graph.add_edge(1, 0, type='employee', features=np.array([0, 1, 2], dtype=np.float32))
-        input_graph.add_node(1, type='employment', features=np.array([0, 1, 2], dtype=np.float32))
-        input_graph.add_edge(1, 2, type='employer', features=np.array([0, 1, 2], dtype=np.float32))
-        input_graph.add_node(2, type='company', features=np.array([0, 1, 2], dtype=np.float32))
+        input_graph.add_node(0, features=np.array([0, 1, 2], dtype=np.float32))
+        input_graph.add_edge(1, 0, features=np.array([0, 1, 2], dtype=np.float32))
+        input_graph.add_node(1, features=np.array([0, 1, 2], dtype=np.float32))
+        input_graph.add_edge(1, 2, features=np.array([0, 1, 2], dtype=np.float32))
+        input_graph.add_node(2, features=np.array([0, 1, 2], dtype=np.float32))
         input_graph.graph['features'] = np.zeros(5, dtype=np.float32)
 
         target_graph = nx.MultiDiGraph()
-        # TODO Remove 'input' and 'solution' fields, only needed for plotting which should be separated
-        target_graph.add_node(0, type='person', features=np.array([0, 1, 0], dtype=np.float32))
-        target_graph.add_edge(1, 0, type='employee', features=np.array([0, 0, 1], dtype=np.float32))
-        target_graph.add_node(1, type='employment', features=np.array([0, 0, 1], dtype=np.float32))
-        target_graph.add_edge(1, 2, type='employer', features=np.array([0, 0, 1], dtype=np.float32))
-        target_graph.add_node(2, type='company', features=np.array([0, 1, 0], dtype=np.float32))
+        target_graph.add_node(0, features=np.array([0, 1, 0], dtype=np.float32))
+        target_graph.add_edge(1, 0, features=np.array([0, 0, 1], dtype=np.float32))
+        target_graph.add_node(1, features=np.array([0, 0, 1], dtype=np.float32))
+        target_graph.add_edge(1, 2, features=np.array([0, 0, 1], dtype=np.float32))
+        target_graph.add_node(2, features=np.array([0, 1, 0], dtype=np.float32))
         target_graph.graph['features'] = np.zeros(5, dtype=np.float32)
 
-        thing_embedder = ThingEmbedder(node_types=['person', 'employment', 'employee'], type_embedding_dim=5,
+        thing_embedder = ThingEmbedder(node_types=['a', 'b', 'c'], type_embedding_dim=5,
                                        attr_embedding_dim=6, categorical_attributes={}, continuous_attributes={})
 
         role_embedder = RoleEmbedder(num_edge_types=2, type_embedding_dim=5)

--- a/kglib/kgcn/learn/learn_IT.py
+++ b/kglib/kgcn/learn/learn_IT.py
@@ -23,7 +23,6 @@ import networkx as nx
 import numpy as np
 
 from kglib.kgcn.learn.learn import KGCNLearner
-from kglib.kgcn.models.attribute import BlankAttribute
 from kglib.kgcn.models.core import KGCN
 from kglib.kgcn.models.embedding import ThingEmbedder, RoleEmbedder
 

--- a/kglib/kgcn/models/core.py
+++ b/kglib/kgcn/models/core.py
@@ -51,8 +51,7 @@ class MLPGraphIndependent(snt.AbstractModule):
         with self._enter_variable_scope():
             self._network = GraphIndependent(
                 edge_model_fn=make_mlp_model,
-                node_model_fn=make_mlp_model,
-                global_model_fn=make_mlp_model)
+                node_model_fn=make_mlp_model)
 
     def _build(self, inputs):
         return self._network(inputs)
@@ -104,7 +103,7 @@ class KGCN(snt.AbstractModule):
             self._encoder = self._kg_encoder()
             self._core = MLPInteractionNetwork()
             self._decoder = MLPGraphIndependent()
-            self._output_transform = modules.GraphIndependent(edge_fn, node_fn, None)
+            self._output_transform = modules.GraphIndependent(edge_fn, node_fn)
 
     def _edge_model(self):
         return snt.Sequential([self._role_embedder,
@@ -117,7 +116,7 @@ class KGCN(snt.AbstractModule):
                                snt.LayerNorm()])
 
     def _kg_encoder(self):
-        return GraphIndependent(self._edge_model, self._node_model, make_mlp_model, name='kg_encoder')
+        return GraphIndependent(self._edge_model, self._node_model, name='kg_encoder')
 
     def _build(self, input_op, num_processing_steps):
         latent = self._encoder(input_op)

--- a/kglib/kgcn/models/core.py
+++ b/kglib/kgcn/models/core.py
@@ -58,14 +58,13 @@ class MLPGraphIndependent(snt.AbstractModule):
         return self._network(inputs)
 
 
-class MLPGraphNetwork(snt.AbstractModule):
-    """GraphNetwork with MLP edge, node, and global models."""
+class MLPInteractionNetwork(snt.AbstractModule):
+    """InteractionNetwork with MLP edge, node, and global models."""
 
-    def __init__(self, name="MLPGraphNetwork"):
-        super(MLPGraphNetwork, self).__init__(name=name)
+    def __init__(self, name="MLPInteractionNetwork"):
+        super(MLPInteractionNetwork, self).__init__(name=name)
         with self._enter_variable_scope():
-            self._network = modules.GraphNetwork(make_mlp_model, make_mlp_model,
-                                                 make_mlp_model)
+            self._network = modules.InteractionNetwork(make_mlp_model, make_mlp_model)
 
     def _build(self, inputs):
         return self._network(inputs)
@@ -103,7 +102,7 @@ class KGCN(snt.AbstractModule):
             node_fn = lambda: snt.Linear(node_output_size, name="node_output")
         with self._enter_variable_scope():
             self._encoder = self._kg_encoder()
-            self._core = MLPGraphNetwork()
+            self._core = MLPInteractionNetwork()
             self._decoder = MLPGraphIndependent()
             self._output_transform = modules.GraphIndependent(edge_fn, node_fn, None)
 

--- a/kglib/kgcn/pipeline/utils_test.py
+++ b/kglib/kgcn/pipeline/utils_test.py
@@ -37,30 +37,30 @@ class TestDuplicateEdgesInReverse(GraphTestCase):
         par0 = Thing('V789', 'parentship', 'relation')
 
         # people
-        graph.add_node(p0, type='person', input=1, solution=1)
-        graph.add_node(p1, type='person', input=1, solution=1)
+        graph.add_node(p0, type='person', solution=1)
+        graph.add_node(p1, type='person', solution=1)
 
         # parentships
-        graph.add_node(par0, type='parentship', input=1, solution=1)
-        graph.add_edge(par0, p0, type='parent', input=1, solution=1)
-        graph.add_edge(par0, p1, type='child', input=1, solution=1)
+        graph.add_node(par0, type='parentship', solution=1)
+        graph.add_edge(par0, p0, type='parent', solution=1)
+        graph.add_edge(par0, p1, type='child', solution=1)
 
         duplicate_edges_in_reverse(graph)
 
         expected_graph = nx.MultiDiGraph(name=0)
 
         # people
-        expected_graph.add_node(p0, type='person', input=1, solution=1)
-        expected_graph.add_node(p1, type='person', input=1, solution=1)
+        expected_graph.add_node(p0, type='person', solution=1)
+        expected_graph.add_node(p1, type='person', solution=1)
 
         # parentships
-        expected_graph.add_node(par0, type='parentship', input=1, solution=1)
-        expected_graph.add_edge(par0, p0, type='parent', input=1, solution=1)
-        expected_graph.add_edge(par0, p1, type='child', input=1, solution=1)
+        expected_graph.add_node(par0, type='parentship', solution=1)
+        expected_graph.add_edge(par0, p0, type='parent', solution=1)
+        expected_graph.add_edge(par0, p1, type='child', solution=1)
 
         # Duplicates
-        expected_graph.add_edge(p0, par0, type='parent', input=1, solution=1)
-        expected_graph.add_edge(p1, par0, type='child', input=1, solution=1)
+        expected_graph.add_edge(p0, par0, type='parent', solution=1)
+        expected_graph.add_edge(p1, par0, type='child', solution=1)
         self.assertGraphsEqual(expected_graph, graph)
 
 


### PR DESCRIPTION
## What is the goal of this PR?

Slim down complexity of the model by removing unused elements.

## What are the changes implemented in this PR?

- The global block of the neural network has never been used. Now using an `Interaction Network` (node and edge updates) rather than the previous `Graph Network` (node, edge and global updates).
- Remove the `input` field that was stored on graphs, since this information can easily be inferred from the 0th class of the `solution` field.