### PR TITLE
Update client-python dependency for pip distribution

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -29,7 +29,7 @@ assemble_pip(
     license = "Apache-2.0",
     install_requires=[
         'enum-compat==0.0.2',
-        'grakn-client==1.5.4',
+        'grakn-client==1.6.0',
         'absl-py==0.8.0',
         'astor==0.8.0',
         'cloudpickle==1.2.2',

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -12,12 +12,12 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        commit = "874f8c7ae14e2f267a88e481b8e207b38d5eded9"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit = "86f8a19a9bdac3093f5d131e0fe07667b047ca82"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_client_python():
     git_repository(
         name = "graknlabs_client_python",
         remote = "https://github.com/graknlabs/client-python",
-        commit = "57bc412856a755254d44aabc1d6eab4ea560154f" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_python
+        commit = "334376cb614086cc8fbcd7238285e8947c97c2e2" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_python
     )


### PR DESCRIPTION
## What is the goal of this PR?

Update the version of the Python client that the PyPi distribution depends upon. This is necessary since Grakn's GRPC protocol has been updated.

## What are the changes implemented in this PR?

- Updates the version of `grakn-client` to depend upon
- Manually sync dependencies client-python and grakn core for bazel purposes