### PR TITLE
Diagnosis Example Fixes

### DIFF
--- a/kglib/kgcn/examples/diagnosis/diagnosis.py
+++ b/kglib/kgcn/examples/diagnosis/diagnosis.py
@@ -261,8 +261,8 @@ def get_thing_types(tx):
         "match $x sub thing; "
         "not {$x sub @has-attribute;}; "
         "not {$x sub @key-attribute;}; "
-        "get;").get('x')
-    thing_types = [schema_concept.label() for schema_concept in schema_concepts]
+        "get;")
+    thing_types = [schema_concept.get('x').label() for schema_concept in schema_concepts]
     [thing_types.remove(el) for el in
      ['thing', 'relation', 'entity', 'attribute', 'candidate-diagnosis', 'example-id', 'probability-exists',
       'probability-non-exists', 'probability-preexists']]
@@ -284,8 +284,8 @@ def get_role_types(tx):
         "not{$x sub @key-attribute-owner;}; "
         "not{$x sub @has-attribute-value;}; "
         "not{$x sub @has-attribute-owner;};"
-        "get;").get('x')
-    role_types = ['has'] + [role.label() for role in schema_concepts]
+        "get;")
+    role_types = ['has'] + [role.get('x').label() for role in schema_concepts]
     [role_types.remove(el) for el in ['role', 'candidate-patient', 'candidate-diagnosed-disease']]
     return role_types
 

--- a/kglib/kgcn/examples/diagnosis/diagnosis_test.py
+++ b/kglib/kgcn/examples/diagnosis/diagnosis_test.py
@@ -53,8 +53,9 @@ class TestWritePredictionsToGrakn(unittest.TestCase):
         expected_query = (f'match'
                           f'$p id V123;'
                           f'$d id V1235;'
+                          f'$kgcn isa kgcn;'
                           f'insert'
-                          f'$pd(predicted-patient: $p, predicted-diagnosed-disease: $d) isa predicted-diagnosis,'
+                          f'$pd(patient: $p, diagnosed-disease: $d, diagnoser: $kgcn) isa diagnosis,'
                           f'has probability-exists 0.993,'
                           f'has probability-non-exists 0.007,'
                           f'has probability-preexists 0.000;')

--- a/kglib/utils/graph/thing/queries_to_graph_it.py
+++ b/kglib/utils/graph/thing/queries_to_graph_it.py
@@ -194,9 +194,9 @@ class ITBuildGraphFromQueriesWithRealGrakn(GraphTestCase):
             with session.transaction().read() as tx:
                 combined_graph = build_graph_from_queries(query_sampler_variable_graph_tuples, tx)
 
-                person_exp = build_thing(list(tx.query('match $x isa person; get;'))[0].get('x'))
-                name_exp = build_thing(list(tx.query('match $x isa name; get;'))[0].get('x'))
-                parentship_exp = build_thing(list(tx.query('match $x isa parentship; get;'))[0].get('x'))
+                person_exp = build_thing(next(tx.query('match $x isa person; get;')).get('x'))
+                name_exp = build_thing(next(tx.query('match $x isa name; get;')).get('x'))
+                parentship_exp = build_thing(next(tx.query('match $x isa parentship; get;')).get('x'))
 
         expected_combined_graph = nx.MultiDiGraph()
         expected_combined_graph.add_node(person_exp, type='person')

--- a/kglib/utils/graph/thing/queries_to_graph_it.py
+++ b/kglib/utils/graph/thing/queries_to_graph_it.py
@@ -194,9 +194,9 @@ class ITBuildGraphFromQueriesWithRealGrakn(GraphTestCase):
             with session.transaction().read() as tx:
                 combined_graph = build_graph_from_queries(query_sampler_variable_graph_tuples, tx)
 
-                person_exp = build_thing(tx.query('match $x isa person; get;').collect_concepts()[0])
-                name_exp = build_thing(tx.query('match $x isa name; get;').collect_concepts()[0])
-                parentship_exp = build_thing(tx.query('match $x isa parentship; get;').collect_concepts()[0])
+                person_exp = build_thing(list(tx.query('match $x isa person; get;'))[0].get('x'))
+                name_exp = build_thing(list(tx.query('match $x isa name; get;'))[0].get('x'))
+                parentship_exp = build_thing(list(tx.query('match $x isa parentship; get;'))[0].get('x'))
 
         expected_combined_graph = nx.MultiDiGraph()
         expected_combined_graph.add_node(person_exp, type='person')


### PR DESCRIPTION
## What is the goal of this PR?

Fixes for the update to the diagnosis example.

## What are the changes implemented in this PR?

- Removes references to `.collect_concepts()` in favour of `.get(<var>)` for each element of the iterator.
- Fixes diagnosis_test according to the new queries made to ingest predictions into Grakn