### PR TITLE
Remove reference to @graknlabs_benchmark

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -98,7 +98,6 @@ load(
     "graknlabs_protocol",
     "graknlabs_client_java",
     "graknlabs_console",
-    "graknlabs_benchmark",
     "graknlabs_grabl_tracing"
 )
 graknlabs_graql()
@@ -106,7 +105,6 @@ graknlabs_common()
 graknlabs_protocol()
 graknlabs_client_java()
 graknlabs_console()
-graknlabs_benchmark()
 graknlabs_grabl_tracing()
 
 load("@graknlabs_grabl_tracing//dependencies/maven:dependencies.bzl",
@@ -173,14 +171,6 @@ antlr_dependencies()
 load("@graknlabs_graql//dependencies/maven:dependencies.bzl",
 graknlabs_graql_maven_dependencies = "maven_dependencies")
 graknlabs_graql_maven_dependencies()
-
-
-###########################
-# Load Benchmark dependencies #
-###########################
-load("@graknlabs_benchmark//dependencies/maven:dependencies.bzl",
-graknlabs_benchmark_maven_dependencies = "maven_dependencies")
-graknlabs_benchmark_maven_dependencies()
 
 
 #######################################


### PR DESCRIPTION
## What is the goal of this PR?

CI is broken because it's trying to load a transitive dependency to `benchmark` which is no longer there

## What are the changes implemented in this PR?

Remove reference to `@graknlabs_benchmark` which is now archived
