### PR TITLE
Fix CI issues related to Python upgrade

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,6 +1,6 @@
 exports_files(["requirements.txt"])
 
-load("@io_bazel_rules_python//python:python.bzl", "py_library", "py_test")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
 load("@pypi_dependencies//:requirements.bzl", "requirement")
 load("@graknlabs_bazel_distribution_pip//:requirements.bzl", deployment_requirement = "requirement")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,13 +12,15 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 # We require loading bazel_rules from the graknlabs fork, not from bazel, since we've patched the python rules to work with TensorFlow
-load("//dependencies/python:dependencies.bzl", "io_bazel_rules_python")
-io_bazel_rules_python()
+load("//dependencies/python:dependencies.bzl", "rules_python")
+rules_python()
 
 ## Only needed for PIP support:
-load("@io_bazel_rules_python//python:pip.bzl", "pip_repositories", "pip3_import")
-pip_repositories()
+load("@rules_python//python:repositories.bzl", "py_repositories")
+py_repositories()
 
+load("@rules_python//python:pip.bzl", "pip_repositories", "pip3_import")
+pip_repositories()
 
 ########################################################################################################################
 # Load Build Tools
@@ -135,8 +137,6 @@ checkstyle_dependencies()
 load("@graknlabs_build_tools//sonarcloud:dependencies.bzl", "sonarcloud_dependencies")
 sonarcloud_dependencies()
 
-load("@graknlabs_build_tools//bazel:dependencies.bzl", "bazel_rules_python")
-bazel_rules_python()
 
 pip3_import(
     name = "graknlabs_build_tools_ci_pip",

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -4,7 +4,7 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "6cf8cad67fa232d020869fde84e56984bf36d5e7", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "715e4802ea375abda44e24b2bb092ee14de72e42", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 
@@ -12,12 +12,12 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        commit = "6c07d56b4458f62962e08aaab44b68eb1275e6e3"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        tag = "1.7.1"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_client_python():
     git_repository(
         name = "graknlabs_client_python",
         remote = "https://github.com/graknlabs/client-python",
-        tag = "1.6.1" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_python
+        commit = "1382eedb01814ab0222d80e0c7d35d7265a802df" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_python
     )

--- a/dependencies/python/dependencies.bzl
+++ b/dependencies/python/dependencies.bzl
@@ -1,10 +1,10 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 
-def io_bazel_rules_python():
+def rules_python():
     git_repository(
-        name = "io_bazel_rules_python",
+        name = "rules_python",
         # Grakn python rules
         remote = "https://github.com/graknlabs/rules_python.git",
-        commit = "4443fa25feac79b0e4c7c63ca84f87a1d6032f49"  
+        commit = "ee519e17ed5265bdd2431937bd271e3b76ad5b0a"
     )

--- a/kglib/BUILD
+++ b/kglib/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_python//python:python.bzl", "py_library", "py_test")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
 load("@graknlabs_bazel_distribution_pip//:requirements.bzl", deployment_requirement = "requirement")
 
 py_library(

--- a/kglib/kgcn/BUILD
+++ b/kglib/kgcn/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_python//python:python.bzl", "py_library")
+load("@rules_python//python:defs.bzl", "py_library")
 
 
 py_library(

--- a/kglib/kgcn/examples/diagnosis/BUILD
+++ b/kglib/kgcn/examples/diagnosis/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_python//python:python.bzl", "py_test", "py_library")
+load("@rules_python//python:defs.bzl", "py_test", "py_library")
 load("@pypi_dependencies//:requirements.bzl", "requirement")
 
 py_test(

--- a/kglib/kgcn/learn/BUILD
+++ b/kglib/kgcn/learn/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_python//python:python.bzl", "py_test", "py_library")
+load("@rules_python//python:defs.bzl", "py_test", "py_library")
 load("@pypi_dependencies//:requirements.bzl", "requirement")
 
 py_test(

--- a/kglib/kgcn/models/BUILD
+++ b/kglib/kgcn/models/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_python//python:python.bzl", "py_test", "py_library")
+load("@rules_python//python:defs.bzl", "py_test", "py_library")
 load("@pypi_dependencies//:requirements.bzl", "requirement")
 
 py_test(

--- a/kglib/kgcn/pipeline/BUILD
+++ b/kglib/kgcn/pipeline/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_python//python:python.bzl", "py_test", "py_library")
+load("@rules_python//python:defs.bzl", "py_test", "py_library")
 load("@pypi_dependencies//:requirements.bzl", "requirement")
 
 py_test(

--- a/kglib/kgcn/plot/BUILD
+++ b/kglib/kgcn/plot/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_python//python:python.bzl", "py_test", "py_library")
+load("@rules_python//python:defs.bzl", "py_test", "py_library")
 load("@pypi_dependencies//:requirements.bzl", "requirement")
 
 py_test(

--- a/kglib/utils/BUILD
+++ b/kglib/utils/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_python//python:python.bzl", "py_library")
+load("@rules_python//python:defs.bzl", "py_library")
 
 
 py_library(

--- a/kglib/utils/grakn/BUILD
+++ b/kglib/utils/grakn/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_python//python:python.bzl", "py_library")
+load("@rules_python//python:defs.bzl", "py_library")
 load("@pypi_dependencies//:requirements.bzl", "requirement")
 
 

--- a/kglib/utils/grakn/object/BUILD
+++ b/kglib/utils/grakn/object/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_python//python:python.bzl", "py_library")
+load("@rules_python//python:defs.bzl", "py_library")
 load("@pypi_dependencies//:requirements.bzl", "requirement")
 
 

--- a/kglib/utils/grakn/synthetic/BUILD
+++ b/kglib/utils/grakn/synthetic/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_python//python:python.bzl", "py_library")
+load("@rules_python//python:defs.bzl", "py_library")
 load("@pypi_dependencies//:requirements.bzl", "requirement")
 
 

--- a/kglib/utils/grakn/synthetic/examples/BUILD
+++ b/kglib/utils/grakn/synthetic/examples/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_python//python:python.bzl", "py_test", "py_library")
+load("@rules_python//python:defs.bzl", "py_test", "py_library")
 load("@pypi_dependencies//:requirements.bzl", "requirement")
 
 exports_files(["diagnosis/schema.gql"])

--- a/kglib/utils/grakn/synthetic/statistics/BUILD
+++ b/kglib/utils/grakn/synthetic/statistics/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_python//python:python.bzl", "py_test", "py_library")
+load("@rules_python//python:defs.bzl", "py_test", "py_library")
 load("@pypi_dependencies//:requirements.bzl", "requirement")
 
 py_test(

--- a/kglib/utils/grakn/test/BUILD
+++ b/kglib/utils/grakn/test/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_python//python:python.bzl", "py_library")
+load("@rules_python//python:defs.bzl", "py_library")
 
 
 py_library(

--- a/kglib/utils/grakn/type/BUILD
+++ b/kglib/utils/grakn/type/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_python//python:python.bzl", "py_library")
+load("@rules_python//python:defs.bzl", "py_library")
 load("@pypi_dependencies//:requirements.bzl", "requirement")
 
 

--- a/kglib/utils/graph/BUILD
+++ b/kglib/utils/graph/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_python//python:python.bzl", "py_library")
+load("@rules_python//python:defs.bzl", "py_library")
 
 
 py_library(

--- a/kglib/utils/graph/query/BUILD
+++ b/kglib/utils/graph/query/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_python//python:python.bzl", "py_test", "py_library")
+load("@rules_python//python:defs.bzl", "py_test", "py_library")
 load("@pypi_dependencies//:requirements.bzl", "requirement")
 
 

--- a/kglib/utils/graph/test/BUILD
+++ b/kglib/utils/graph/test/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_python//python:python.bzl", "py_test", "py_library")
+load("@rules_python//python:defs.bzl", "py_test", "py_library")
 
 py_library(
     name = "test",

--- a/kglib/utils/graph/thing/BUILD
+++ b/kglib/utils/graph/thing/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_python//python:python.bzl", "py_test", "py_library")
+load("@rules_python//python:defs.bzl", "py_test", "py_library")
 load("@pypi_dependencies//:requirements.bzl", "requirement")
 
 

--- a/kglib/utils/test/BUILD
+++ b/kglib/utils/test/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_python//python:python.bzl", "py_library")
+load("@rules_python//python:defs.bzl", "py_library")
 
 py_library(
     name = "test",

--- a/tests/end_to_end/BUILD
+++ b/tests/end_to_end/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_python//python:python.bzl", "py_test")
+load("@rules_python//python:defs.bzl", "py_test")
 
 py_test(
     name = "diagnosis",


### PR DESCRIPTION
## What is the goal of this PR?

Recent upgrade to Python 3 in `client-python` broke our CI.

## What are the changes implemented in this PR?

- Upgrade Client Python to latest `master` (contains upgrade to Python 3 but introduces incompatible changes - to be upgraded in next PR)
- Upgrade Grakn Core to 1.7.1 (latest release)
- Use updated `@graknlabs_build_tools`
- Use updated fork of `@rules_python` (Tensorflow patch applied on current latest `master`)
- Use updated imports from `@rules_python`