### PR TITLE
Fix changes incompatible with latest Grakn

### DIFF
--- a/kglib/utils/grakn/object/thing.py
+++ b/kglib/utils/grakn/object/thing.py
@@ -49,16 +49,16 @@ class Thing(PropertyComparable):
         return self.__str__()
 
 
-def build_thing(grakn_thing):
+def build_thing(grakn_thing, tx):
 
     id = grakn_thing.id
     type_label = grakn_thing.type().label()
-    base_type_label = grakn_thing.base_type.lower()
+    base_type_label = grakn_thing.as_remote(tx).base_type.replace('_TYPE', '').lower()
 
     assert(base_type_label in ['entity', 'relation', 'attribute'])
 
     if base_type_label == 'attribute':
-        data_type = grakn_thing.type().data_type().name.lower()
+        data_type = grakn_thing.as_remote(tx).type().data_type().name.lower()
         assert data_type in DATA_TYPE_NAMES
         value = grakn_thing.value()
 

--- a/kglib/utils/grakn/test/mock/concept.py
+++ b/kglib/utils/grakn/test/mock/concept.py
@@ -58,6 +58,9 @@ class MockThing(MockConcept):
     def type(self):
         return self._type
 
+    def as_remote(self, tx):
+        return self
+
     @property
     def base_type(self):
         return self._type.base_type

--- a/kglib/utils/graph/thing/queries_to_graph.py
+++ b/kglib/utils/graph/thing/queries_to_graph.py
@@ -25,7 +25,7 @@ from kglib.utils.grakn.object.thing import build_thing
 from kglib.utils.graph.thing.concept_dict_to_graph import concept_dict_to_graph
 
 
-def concept_dict_from_concept_map(concept_map):
+def concept_dict_from_concept_map(concept_map, tx):
     """
     Given a concept map, build a dictionary of the variables present and the concepts they refer to, locally storing any
     information required about those concepts.
@@ -36,7 +36,7 @@ def concept_dict_from_concept_map(concept_map):
     Returns:
         A dictionary of concepts keyed by query variables
     """
-    return {variable: build_thing(grakn_concept) for variable, grakn_concept in concept_map.map().items()}
+    return {variable: build_thing(grakn_concept, tx) for variable, grakn_concept in concept_map.map().items()}
 
 
 def combine_2_graphs(graph1, graph2):
@@ -109,7 +109,7 @@ def build_graph_from_queries(query_sampler_variable_graph_tuples, grakn_transact
 
         concept_maps = sampler(grakn_transaction.query(query, infer=infer))
 
-        concept_dicts = [concept_dict_from_concept_map(concept_map) for concept_map in concept_maps]
+        concept_dicts = [concept_dict_from_concept_map(concept_map, grakn_transaction) for concept_map in concept_maps]
 
         answer_concept_graphs = []
         for concept_dict in concept_dicts:

--- a/kglib/utils/graph/thing/queries_to_graph_it.py
+++ b/kglib/utils/graph/thing/queries_to_graph_it.py
@@ -194,9 +194,9 @@ class ITBuildGraphFromQueriesWithRealGrakn(GraphTestCase):
             with session.transaction().read() as tx:
                 combined_graph = build_graph_from_queries(query_sampler_variable_graph_tuples, tx)
 
-                person_exp = build_thing(next(tx.query('match $x isa person; get;')).get('x'))
-                name_exp = build_thing(next(tx.query('match $x isa name; get;')).get('x'))
-                parentship_exp = build_thing(next(tx.query('match $x isa parentship; get;')).get('x'))
+                person_exp = build_thing(next(tx.query('match $x isa person; get;')).get('x'), tx)
+                name_exp = build_thing(next(tx.query('match $x isa name; get;')).get('x'), tx)
+                parentship_exp = build_thing(next(tx.query('match $x isa parentship; get;')).get('x'), tx)
 
         expected_combined_graph = nx.MultiDiGraph()
         expected_combined_graph.add_node(person_exp, type='person')

--- a/kglib/utils/graph/thing/queries_to_graph_test.py
+++ b/kglib/utils/graph/thing/queries_to_graph_test.py
@@ -31,7 +31,7 @@ from kglib.utils.graph.test.case import GraphTestCase
 class TestConceptDictsFromQuery(unittest.TestCase):
     def test_concept_dicts_are_built_as_expected(self):
         concept_map = MockConceptMap({'x': MockThing('V123', MockType('V456', 'person', 'ENTITY'))})
-        concept_dicts = concept_dict_from_concept_map(concept_map)
+        concept_dicts = concept_dict_from_concept_map(concept_map, None)
 
         expected_concept_dicts = {'x': Thing('V123', 'person', 'entity')}
 
@@ -43,7 +43,7 @@ class TestConceptDictsFromQuery(unittest.TestCase):
             'y': MockThing('V789', MockType('V765', 'employment', 'RELATION')),
         })
 
-        concept_dicts = concept_dict_from_concept_map(concept_map)
+        concept_dicts = concept_dict_from_concept_map(concept_map, None)
 
         expected_concept_dict = {
             'x': Thing('V123', 'person', 'entity'),


### PR DESCRIPTION
## What is the goal of this PR?

`base_type` is no longer present in local concepts fetched by client, therefore we have to get remote concepts to obtain `base_type`

## What are the changes implemented in this PR?

- `kglib.utils.grakn.object.thing.build_thing` now gets a transaction to obtain concepts' `base_type`