### PR TITLE
Bump grakn-client dependency to 1.7.2

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -29,7 +29,7 @@ assemble_pip(
     license = "Apache-2.0",
     install_requires=[
         'enum-compat==0.0.2',
-        'grakn-client==1.6.0',
+        'grakn-client==1.7.2',
         'absl-py==0.8.0',
         'astor==0.8.0',
         'cloudpickle==1.2.2',


### PR DESCRIPTION
## What is the goal of this PR?

Currently, `kglib` wouldn't quite work since it declares a dependency on old `grakn-client` version incompatible with newest Grakn

## What are the changes implemented in this PR?

Bump `grakn-client` to `1.7.2`