### PR TITLE
Install Python step in test-deployment-pip

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,7 @@ jobs:
     steps:
       - install-bazel
       - checkout
+      - install-python
       - run-grakn
       - run:
           name: Run test-deployment-pip for kglib


### PR DESCRIPTION
## What is the goal of this PR?

`test-deployment-pip` step was missing `install-python` which installs and links the correct Python version.

## What are the changes implemented in this PR?

Add a missing step to `test-deployment-pip`