### PR TITLE
Fix end-to-end test

### DIFF
--- a/kglib/utils/grakn/type/type.py
+++ b/kglib/utils/grakn/type/type.py
@@ -27,11 +27,7 @@ def get_thing_types(tx):
     Returns:
         Grakn types
     """
-    schema_concepts = tx.query(
-        "match $x sub thing; "
-        "not {$x sub @has-attribute;}; "
-        "not {$x sub @key-attribute;}; "
-        "get;")
+    schema_concepts = tx.query("match $x sub thing; get;")
     thing_types = [schema_concept.get('x').label() for schema_concept in schema_concepts]
     [thing_types.remove(el) for el in ['thing', 'relation', 'entity', 'attribute']]
     return thing_types
@@ -46,13 +42,7 @@ def get_role_types(tx):
     Returns:
         Grakn roles
     """
-    schema_concepts = tx.query(
-        "match $x sub role; "
-        "not{$x sub @key-attribute-value;}; "
-        "not{$x sub @key-attribute-owner;}; "
-        "not{$x sub @has-attribute-value;}; "
-        "not{$x sub @has-attribute-owner;};"
-        "get;")
+    schema_concepts = tx.query("match $x sub role; get;")
     role_types = ['has'] + [role.get('x').label() for role in schema_concepts]
     role_types.remove('role')
     return role_types

--- a/tests/end_to_end/kgcn/diagnosis.py
+++ b/tests/end_to_end/kgcn/diagnosis.py
@@ -39,7 +39,7 @@ class TestDiagnosisExample(unittest.TestCase):
         self._gs.stop()
 
     def test_learning_is_done(self):
-        solveds_tr, solveds_ge = diagnosis_example()
+        solveds_tr, solveds_ge = diagnosis_example(20)
         self.assertGreaterEqual(solveds_tr[-1], 0.7)
         self.assertLessEqual(solveds_tr[-1], 0.99)
         self.assertGreaterEqual(solveds_ge[-1], 0.7)
@@ -49,4 +49,4 @@ class TestDiagnosisExample(unittest.TestCase):
 if __name__ == "__main__":
     # This handles the fact that additional arguments that are supplied by our py_test definition
     # https://stackoverflow.com/a/38012249
-    unittest.main(argv=['ignored-arg'], exit=False)
+    unittest.main(argv=['ignored-arg'])

--- a/tests/end_to_end/kgcn/diagnosis.py
+++ b/tests/end_to_end/kgcn/diagnosis.py
@@ -39,7 +39,7 @@ class TestDiagnosisExample(unittest.TestCase):
         self._gs.stop()
 
     def test_learning_is_done(self):
-        solveds_tr, solveds_ge = diagnosis_example(20)
+        solveds_tr, solveds_ge = diagnosis_example()
         self.assertGreaterEqual(solveds_tr[-1], 0.7)
         self.assertLessEqual(solveds_tr[-1], 0.99)
         self.assertGreaterEqual(solveds_ge[-1], 0.7)


### PR DESCRIPTION
## What is the goal of this PR?

We fix the end-to-end test to properly report failure

## What are the changes implemented in this PR?

- Remove incorrect and unneeded parameter supplied to unittest
- This uncovers that `@has-attribute` and friends no longer exist in Grakn 1.8.0, so they are removed