### PR TITLE
Update Build for 2.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -61,17 +61,12 @@ load("@graknlabs_dependencies_ci_pip//:requirements.bzl",
 graknlabs_dependencies_ci_pip_install = "pip_install")
 graknlabs_dependencies_ci_pip_install()
 
-# Load distribution deps
-load("@graknlabs_dependencies//distribution:deps.bzl", distribution_deps = "deps")
-distribution_deps()
-
 # Load maven artifacts
 load("@graknlabs_dependencies//dependencies/maven:artifacts.bzl", graknlabs_dependencies_artifacts = "artifacts")
 
 #####################################################################
 # Load @graknlabs_bazel_distribution (from @graknlabs_dependencies) #
 #####################################################################
-
 load("@graknlabs_dependencies//dependencies/graknlabs:repositories.bzl", "graknlabs_bazel_distribution")
 graknlabs_bazel_distribution()
 
@@ -99,18 +94,6 @@ skydoc_repositories()
 load("@graknlabs_bazel_distribution//common:dependencies.bzl", "bazelbuild_rules_pkg")
 bazelbuild_rules_pkg()
 
-############################
-# Load @graknlabs_protocol #
-############################
-load("//dependencies/graknlabs:repositories.bzl", "graknlabs_protocol")
-graknlabs_protocol()
-
-#######################################
-# Load @graknlabs_grakn_core_artifact #
-#######################################
-load("//dependencies/graknlabs:artifacts.bzl", "graknlabs_grakn_core_artifact")
-graknlabs_grakn_core_artifact()
-
 #################################
 # Load @graknlabs_client_python #
 #################################
@@ -124,6 +107,18 @@ pip3_import(
 load("@graknlabs_client_python_pip//:requirements.bzl",
 graknlabs_client_python_pip_install = "pip_install")
 graknlabs_client_python_pip_install()
+
+############################################################
+# Load @graknlabs_protocol (from @graknlabs_client_python) #
+############################################################
+load("@graknlabs_client_python//dependencies/graknlabs:repositories.bzl", "graknlabs_protocol")
+graknlabs_protocol()
+
+#######################################
+# Load @graknlabs_grakn_core_artifact #
+#######################################
+load("//dependencies/graknlabs:artifacts.bzl", "graknlabs_grakn_core_artifact")
+graknlabs_grakn_core_artifact()
 
 #########################
 # Load @graknlabs_kglib #

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -15,12 +15,15 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-load("@graknlabs_dependencies//distribution/artifact:rules.bzl", "artifact_file")
+load("@graknlabs_bazel_distribution//artifact:rules.bzl", "artifact_file")
+load("@graknlabs_dependencies//distribution:deployment.bzl", "deployment_private")
 
 def graknlabs_grakn_core_artifact():
     artifact_file(
         name = "graknlabs_grakn_core_artifact",
         group_name = "graknlabs_grakn_core",
-        artifact_name = "grakn-core-all-linux-{version}.tar.gz",
-        commit = "1c91c824aa208ad77c14ab7ee3ea6f6de7cff467",
+        artifact_name = "grakn-core-server-linux-{version}.tar.gz",
+        tag_source = deployment_private["artifact.release"],
+        commit_source = deployment_private["artifact.snapshot"],
+        commit = "9dc39b4802af329fc0e6e673779397b58173e22b",
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -22,19 +22,12 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "633cc1f4b457f18c5ad93c2fb28b044537a95ed8",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
-    )
-
-def graknlabs_protocol():
-    git_repository(
-        name = "graknlabs_protocol",
-        remote = "https://github.com/graknlabs/protocol",
-        commit = "ae12f6c3829cd5304f3bb4ba865f5fcc10022738", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "e95e6f7b68eaa2e4908624a8cd99219a423cdacf",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_client_python():
     git_repository(
         name = "graknlabs_client_python",
         remote = "https://github.com/graknlabs/client-python",
-        tag = "1.8.0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_python
+        commit = "140ca3eda271b12ff6727db070e642ea10c61433" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_python
     )

--- a/deployment.bzl
+++ b/deployment.bzl
@@ -16,5 +16,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-repo.github.organisation=graknlabs
-repo.github.repository=kglib
+deployment = {
+    "github.organisation" : "graknlabs",
+    "github.repository" : "kglib"
+}


### PR DESCRIPTION
## What is the goal of this PR?
Update to the new style of dependencies and deployment, in line for 2.0 - style infrastructure. This includes using a `deployment.bzl` and pulling `bazel-distribution` via `dependencies`.

**NOTE** until 2.0 clients and server are ready, merging this PR will break the build and runnability of `kglib`

## What are the changes implemented in this PR?
* Bump dependencies
* Update WORKSPACE file: pull `protocol` via `client-python`, pull `bazel-distribution` via `dependencies`
* Update `deployment.properties` to become `deployment.bzl`