### PR TITLE
[Development] Refactor WORKSPACE and add filegroup declaring CI targets

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -98,3 +98,13 @@ release_validate_deps(
     ],
     tags = ["manual"]
 )
+
+# CI targets that are not declared in any BUILD file, but are called externally
+filegroup(
+    name = "ci",
+    data = [
+        "@graknlabs_dependencies//library/maven:update",
+        "@graknlabs_dependencies//tool/bazelrun:rbe",
+        "@graknlabs_dependencies//tool/release:approval"
+    ]
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,83 +20,72 @@ workspace(name = "graknlabs_kglib")
 ################################
 # Load @graknlabs_dependencies #
 ################################
+
 load("//dependencies/graknlabs:repositories.bzl", "graknlabs_dependencies")
 graknlabs_dependencies()
 
-# Load Bazel
+# Load //builder/bazel for RBE
 load("@graknlabs_dependencies//builder/bazel:deps.bzl", "bazel_toolchain")
 bazel_toolchain()
 
-# Load gRPC
+# Load //builder/grpc
 load("@graknlabs_dependencies//builder/grpc:deps.bzl", grpc_deps = "deps")
 grpc_deps()
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl",
 com_github_grpc_grpc_deps = "grpc_deps")
 com_github_grpc_grpc_deps()
 
-# Load Java
+# Load //builder/java
 load("@graknlabs_dependencies//builder/java:deps.bzl", java_deps = "deps")
 java_deps()
-load("@graknlabs_dependencies//library/maven:rules.bzl", "maven")
 
-# Load Kotlin
+# Load //builder/kotlin
 load("@graknlabs_dependencies//builder/kotlin:deps.bzl", kotlin_deps = "deps")
 kotlin_deps()
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
 kotlin_repositories()
 kt_register_toolchains()
 
-# Load Python
+# Load //builder/python
 load("@graknlabs_dependencies//builder/python:deps.bzl", python_deps = "deps")
 python_deps(use_patched_version=True)
 load("@rules_python//python:pip.bzl", "pip_repositories", "pip3_import")
 pip_repositories()
 
-# Load graknlabs_dependencies_ci_pip (for @graknlabs_dependencies//tool/sync:dependencies)
-pip3_import(
-    name = "graknlabs_dependencies_ci_pip",
-    requirements = "@graknlabs_dependencies//tool:requirements.txt",
-)
-load("@graknlabs_dependencies_ci_pip//:requirements.bzl",
-graknlabs_dependencies_ci_pip_install = "pip_install")
-graknlabs_dependencies_ci_pip_install()
+# Load //tool/common
+load("@graknlabs_dependencies//tool/common:deps.bzl", "graknlabs_dependencies_ci_pip",
+    graknlabs_dependencies_tool_maven_artifacts = "maven_artifacts")
+graknlabs_dependencies_ci_pip()
+load("@graknlabs_dependencies_ci_pip//:requirements.bzl", graknlabs_dependencies_pip_install = "pip_install")
+graknlabs_dependencies_pip_install()
 
-# Load maven artifacts
-load("@graknlabs_dependencies//dependencies/maven:artifacts.bzl", graknlabs_dependencies_artifacts = "artifacts")
+######################################
+# Load @graknlabs_bazel_distribution #
+######################################
 
-#####################################################################
-# Load @graknlabs_bazel_distribution (from @graknlabs_dependencies) #
-#####################################################################
-load("@graknlabs_dependencies//dependencies/graknlabs:repositories.bzl", "graknlabs_bazel_distribution")
+load("@graknlabs_dependencies//distribution:deps.bzl", "graknlabs_bazel_distribution")
 graknlabs_bazel_distribution()
 
-pip3_import(
-    name = "graknlabs_bazel_distribution_pip",
-    requirements = "@graknlabs_bazel_distribution//pip:requirements.txt",
-)
-load("@graknlabs_bazel_distribution_pip//:requirements.bzl",
-graknlabs_bazel_distribution_pip_install = "pip_install")
+# Load //common
+load("@graknlabs_bazel_distribution//common:deps.bzl", "rules_pkg")
+rules_pkg()
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+rules_pkg_dependencies()
+
+# Load //pip
+load("@graknlabs_bazel_distribution//pip:deps.bzl", pip_deps = "deps")
+pip_deps()
+load("@graknlabs_bazel_distribution_pip//:requirements.bzl", graknlabs_bazel_distribution_pip_install = "pip_install")
 graknlabs_bazel_distribution_pip_install()
 
-load("@graknlabs_bazel_distribution//github:dependencies.bzl", "tcnksm_ghr")
-tcnksm_ghr()
+# Load //github
+load("@graknlabs_bazel_distribution//github:deps.bzl", github_deps = "deps")
+github_deps()
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-git_repository(
-    name = "io_bazel_skydoc",
-    remote = "https://github.com/graknlabs/skydoc.git",
-    branch = "experimental-skydoc-allow-dep-on-bazel-tools",
-)
+################################
+# Load @graknlabs dependencies #
+################################
 
-load("@io_bazel_skydoc//:setup.bzl", "skydoc_repositories")
-skydoc_repositories()
-
-load("@graknlabs_bazel_distribution//common:dependencies.bzl", "bazelbuild_rules_pkg")
-bazelbuild_rules_pkg()
-
-#################################
-# Load @graknlabs_client_python #
-#################################
 load("//dependencies/graknlabs:repositories.bzl", "graknlabs_client_python")
 graknlabs_client_python()
 
@@ -108,21 +97,12 @@ load("@graknlabs_client_python_pip//:requirements.bzl",
 graknlabs_client_python_pip_install = "pip_install")
 graknlabs_client_python_pip_install()
 
-############################################################
-# Load @graknlabs_protocol (from @graknlabs_client_python) #
-############################################################
 load("@graknlabs_client_python//dependencies/graknlabs:repositories.bzl", "graknlabs_protocol")
 graknlabs_protocol()
 
-#######################################
-# Load @graknlabs_grakn_core_artifact #
-#######################################
 load("//dependencies/graknlabs:artifacts.bzl", "graknlabs_grakn_core_artifact")
 graknlabs_grakn_core_artifact()
 
-#########################
-# Load @graknlabs_kglib #
-#########################
 pip3_import(
     name = "graknlabs_kglib_pip",
     requirements = "//:requirements.txt",
@@ -131,16 +111,17 @@ load("@graknlabs_kglib_pip//:requirements.bzl",
 graknlabs_kglib_pip_install = "pip_install")
 graknlabs_kglib_pip_install()
 
-##############
-# Load @maven #
-##############
-maven(
-    graknlabs_dependencies_artifacts
-)
+############################
+# Load @maven dependencies #
+############################
+
+load("@graknlabs_dependencies//library/maven:rules.bzl", "maven")
+maven(graknlabs_dependencies_tool_maven_artifacts)
 
 ############################################
 # Create @graknlabs_console_workspace_refs #
 ############################################
+
 load("@graknlabs_bazel_distribution//common:rules.bzl", "workspace_refs")
 workspace_refs(
     name = "graknlabs_kglib_workspace_refs"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -88,7 +88,6 @@ github_deps()
 
 load("//dependencies/graknlabs:repositories.bzl", "graknlabs_client_python")
 graknlabs_client_python()
-
 pip3_import(
     name = "graknlabs_client_python_pip",
     requirements = "@graknlabs_client_python//:requirements.txt",

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -22,7 +22,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "e95e6f7b68eaa2e4908624a8cd99219a423cdacf",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "1c86421327bec68a83c3f88d728add07010f797a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_client_python():


### PR DESCRIPTION
## What is the goal of this PR?

We refactor the WORKSPACE file to make it clearer. The key change was to properly enclose declarations into appropriate sections. We also add a new toplevel BUILD file declaration for all targets used in CI and elsewhere to ensure these targets are correct at build time.
